### PR TITLE
add logic to retrieve PR from API as fallback

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
   test_action:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ multiple runs. Upsert, post, delete comments.
 
 # Usage
 ## Post a comment
-To simply post a comment in the current PR.
+To simply post a comment in the current PR. By default, the Pull Request ID is
+determined automatically from the github context or an API call to retrieve
+PRs associated with the commit.
 ```
 - uses: direct-actions/pr-comment@v0.1.0
   with:

--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,11 @@ inputs:
     description: Body of comment, used with `post` or `upsert` operation.
     required: false
     type: string
+  error-on-missing-pr:
+    default: 'true'
+    description: Override with 'false' to suppress errors when the PR cannot be determined.
+    required: false
+    type: string
   key:
     default: ''
     description: (Optional) Unique & hidden key used to match comment(s) across operations.
@@ -45,8 +50,8 @@ inputs:
     required: false
     type: string
   pull-request:
-    default: ${{ github.event.number }}
-    description: Override pull request number (default is auto-determined based on pull_request event).
+    default:
+    description: Override pull request number (default is auto-determined based on event or API query).
     required: false
     type: string
   quiet:
@@ -81,6 +86,9 @@ outputs:
   json-output:
     description: JSON output of last API operation.
     value: ${{ steps.operation.outputs.json-output }}
+  pull-request:
+    description: Pull request ID as discovered or passed in.
+    value: ${{ steps.operation.outputs.pull-request }}
 
 runs:
   using: composite
@@ -89,11 +97,13 @@ runs:
         CLASSIFIER: ${{ inputs.classifier }}
         COMMENT: ${{ inputs.comment }}
         COMMENT_KEY: ${{ inputs.key }}
+        ERROR_ON_MISSING_PR: ${{ inputs.error-on-missing-pr }}
         GITHUB_TOKEN: ${{ inputs.token }}
         OPERATION: ${{ inputs.operation }}
         PULL_REQUEST: ${{ inputs.pull-request }}
         QUIET: ${{ inputs.quiet }}
         REPOSITORY: ${{ inputs.repository }}
+        SHA: ${{ github.sha }}
       id: operation
       if: ${{ inputs.operation != 'post' }}
       run: |
@@ -112,7 +122,7 @@ runs:
           local url query
           local operation=$1
           local method=$2
-          local comment=$4
+          local body=$4
           local output=$5
           if [ -z "$output" ] ; then
             output=$(mktemp)
@@ -129,7 +139,7 @@ runs:
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "$url" \
-              -f body="${comment}" \
+              -f body="${body}" \
               >"$output" 2>"$ERROR" || failed=true
           fi
 
@@ -152,12 +162,29 @@ runs:
           jq -r '"json-output<<_EOF_\n\(@json)\n_EOF_\n"' "$output" >> "$GITHUB_OUTPUT"
         }
 
+        PULL_REQUEST=${PULL_REQUEST:-${{ github.event.number }}}
         if [ -z "$PULL_REQUEST" ] ; then
-          echo "::error title=direct-actions/pr-comment - Cannot determine" \
-            "pull request::Cannot determine pull request number in this" \
-            "sitation, pass explicitly via pull-request input."
-          exit 1
-        elif [ -z "$REPOSITORY" ] ; then
+          API_OUTPUT=$(mktemp)
+          gh_api 'get-pr-associated-with-commit' GET "/repos/${REPOSITORY}/commits/${SHA}/pulls" '' "$API_OUTPUT"
+          PULL_REQUEST=$(jq first.id "$API_OUTPUT")
+          if [ -z "$PULL_REQUEST" ] ; then
+            if [ "$QUIET" = 'true' ] || [ "$ERROR_ON_MISSING_PR" != 'true' ] ; then
+              echo 'Cannot determine pull request ID, exiting.'
+            else
+              echo "::error title=direct-actions/pr-comment - Cannot determine" \
+                "pull request::Cannot determine pull request ID in this" \
+                "sitation, pass explicitly via pull-request input."
+            fi
+            if [ "$ERROR_ON_MISSING_PR" == 'true' ] ; then
+              exit 1
+            else
+              exit 0
+            fi
+          fi
+          echo "pull-request=${PULL_REQUEST}" >>"${GITHUB_OUTPUT}"
+        fi
+
+        if [ -z "$REPOSITORY" ] ; then
           echo "::error title=direct-actions/pr-comment - Cannot determine" \
             "repository::Cannot determine repository in this situation, pass" \
             "explicitly via repository input."


### PR DESCRIPTION
Allows this action to work on `push` as well as `pull_request` events.